### PR TITLE
Change helper UDF functions to closures

### DIFF
--- a/views/whoops.cfm
+++ b/views/whoops.cfm
@@ -80,7 +80,7 @@
 
     }
 
-    function displayScope (scope) {
+    displayScope = function(scope) {
         var list = '<table class="data-table"><tbody>';
         var orderedArr = scope;
         if(structKeyExists(scope,'itemorder')) orderedArr = scope.itemorder;
@@ -107,7 +107,7 @@
         return list;
     }
 
-    function openInEditorURL( required event, required struct instance ) {
+    openInEditorURL = function( required event, required struct instance ) {
         var editor = event.getController().getUtil().getSystemSetting( "WHOOPS_EDITOR", "" );
         switch( editor ) {
             case "vscode":


### PR DESCRIPTION
This fixes an unexplained `routines may not be declared more than once` error that will occur sometimes, on ACF, within different contexts of the Coldbox 5 bootstrap.  This error is intermittent only occurs within certain request contexts.  Changing to closures is more dependable.