### PR TITLE
Scope issue

### DIFF
--- a/views/whoops.cfm
+++ b/views/whoops.cfm
@@ -273,7 +273,7 @@
                         </div>
                         <div  id="stacktrace_scope" class="data-table">
                             <label>Raw Stack Trace</label>
-                            <div class="data-stacktrace">#processStackTrace( oException.getstackTrace() )#</div>
+                            <div class="data-stacktrace">#oException.processStackTrace( oException.getstackTrace() )#</div>
                         </div>
                     </div>
                     </cfoutput>


### PR DESCRIPTION


For some reason, on certain machines, this error comes up. Scoping the function resolves this issue.

No matching function [PROCESSSTACKTRACE] found

\modules\whoops\views\whoops.cfm: line 276
\coldbox\system\Bootstrap.cfc: line 646
\coldbox\system\Bootstrap.cfc: line 395
\coldbox\system\Bootstrap.cfc: line 483
\Application.cfc: line 40

